### PR TITLE
publish macos too

### DIFF
--- a/corpora-i-ching/src-tauri/.gitignore
+++ b/corpora-i-ching/src-tauri/.gitignore
@@ -1,4 +1,6 @@
 *.plist
+!macos-entitlements.plist
+*.pkg
 apple-signing/
 *.pem
 *.cer

--- a/corpora-i-ching/src-tauri/macos-entitlements.plist
+++ b/corpora-i-ching/src-tauri/macos-entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+</dict>
+</plist>

--- a/corpora-i-ching/src-tauri/tauri.conf.json
+++ b/corpora-i-ching/src-tauri/tauri.conf.json
@@ -40,6 +40,10 @@
       "minimumSystemVersion": "14.0",
       "developmentTeam": "F9AV5HKF6N",
       "template": "ios/project.yml"
+    },
+    "macOS": {
+      "entitlements": "macos-entitlements.plist",
+      "signingIdentity": "3rd Party Mac Developer Application: Corpora Inc (F9AV5HKF6N)"
     }
   }
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add macOS sandbox entitlements plist

- Enable sandboxing for macOS builds

- Add macOS section to Tauri config

- Specify macOS signing identity


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>macos-entitlements.plist</strong><dd><code>Add macOS sandbox entitlements plist</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpora-i-ching/src-tauri/macos-entitlements.plist

<li>Create new macos-entitlements.plist file<br> <li> Enable <code>com.apple.security.app-sandbox</code> entitlement


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/yijing/pull/23/files#diff-85f287b47a0e9c39457644d33a85afadd45190fd999885366e1a2415fac53726">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tauri.conf.json</strong><dd><code>Configure macOS settings in Tauri config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpora-i-ching/src-tauri/tauri.conf.json

<li>Add <code>macOS</code> build configuration section<br> <li> Reference <code>macos-entitlements.plist</code> entitlements<br> <li> Set <code>signingIdentity</code> for macOS application


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/yijing/pull/23/files#diff-c94289aa188b986566b40209861cb84190dd6788d90164e1d42fbb43c723a215">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>